### PR TITLE
Provide interface for setting custom rules for updating previous values

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,60 @@ Since Svelte automatically bundles all required dependencies, you only need to i
 from {$previous} to {$current}.
 ```
 
-### Multiple previous values
+## Options
 
-To track more than one value, pass the number of previous values to track as the second argument to `withPrevious`.
+`withPrevious` takes an options object as its second argument.
+
+### `numToTrack: number`
+
+By default, `withPrevious` tracks one previous value.
+
+To track more than one value, set `numToTrack`.
 
 ```svelte
 <script>
-  const [current, prev1, prev2] = withPrevious(0, 2);
+  const [current, prev1, prev2] = withPrevious(0, { numToTrack: 2 });
   setInterval(() => $current++, 1000);
 </script>
 
 from {$prev2} to {$prev1} to {$current}.
+```
+
+### `requireChange: boolean`
+
+Due to how reactivity is handled in Svelte, some assignments may assign the same value multiple times to a variable. Therefore, to prevent a single value from overwriting all previous values, a change in value is required before the current and previous values are updated.
+
+Set `requireChange = false` to change this behaviour.
+
+```svelte
+<script>
+  const [current, previous] = withPrevious(0, { requireChange: false });
+</script>
+```
+
+### `isEqual: (a: T, b: T) => boolean`
+
+By default, equality is determined with the `===` operator. However, `===` only checks equality by reference when comparing objects.
+
+Provide a custom `isEqual` function to compare objects.
+
+```svelte
+<script>
+  const [current, previous] = withPrevious(0, {
+    isEqual: (a, b) => a.name === b.name && a.age === b.age,
+  });
+</script>
+```
+
+It is also possible to use [lodash.isequal](https://www.npmjs.com/package/lodash.isequal).
+
+```svelte
+<script>
+  import isEqual from 'lodash.isequal';
+
+  const [current, previous] = withPrevious(0, {
+    isEqual: isEqual,
+  });
+</script>
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-previous",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Svelte stores that remember previous values",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -10,7 +10,7 @@ test('init', () => {
   expect(get(previous)).toBeNull();
 });
 
-test('set one value', () => {
+test('set one previous value', () => {
   // Arrange
   const [current, previous] = withPrevious(0);
 
@@ -24,7 +24,7 @@ test('set one value', () => {
   expect(get(previous)).toBe(1);
 });
 
-test('init three values', () => {
+test('init two previous values', () => {
   // Arrange
   const [current, prev1, prev2] = withPrevious(0, { numToTrack: 2 });
 
@@ -34,7 +34,7 @@ test('init three values', () => {
   expect(get(prev2)).toBeNull();
 });
 
-test('set two values', () => {
+test('set two previous values', () => {
   // Arrange
   const [current, prev1, prev2] = withPrevious(0, { numToTrack: 2 });
 
@@ -58,6 +58,17 @@ test('set two values', () => {
 test('init invalid no values', () => {
   expect(withPrevious.bind(this, 0, { numToTrack: 0 }))
       .toThrow('Must track at least 1 previous');
+});
+
+test('update when equal', () => {
+  // Arrange
+  const [current, previous] = withPrevious(0, { requireChange: false });
+
+  // Act and Assert
+  current.set(1);
+  current.set(1);
+  expect(get(current)).toBe(1);
+  expect(get(previous)).toBe(1);
 });
 
 test('no update when equal', () => {
@@ -85,5 +96,20 @@ test('no update when equal object value', () => {
   current.set(secondCopy);
   expect(get(current)).toBe(second);
   expect(get(previous)).toBe(first);
+});
+
+test('update when equal object value, two previous values', () => {
+  // Arrange
+  const [current, prev1, prev2] = withPrevious(0, {
+    numToTrack: 2,
+    requireChange: false,
+  });
+
+  // Act and Assert
+  current.set(0);
+  current.set(0);
+  expect(get(current)).toBe(0);
+  expect(get(prev1)).toBe(0);
+  expect(get(prev2)).toBe(0);
 });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -60,3 +60,30 @@ test('init invalid no values', () => {
       .toThrow('Must track at least 1 previous');
 });
 
+test('no update when equal', () => {
+  // Arrange
+  const [current, previous] = withPrevious(0);
+
+  // Act and Assert
+  current.set(1);
+  current.set(1);
+  expect(get(current)).toBe(1);
+  expect(get(previous)).toBe(0);
+});
+
+test('no update when equal object value', () => {
+  // Arrange
+  const first = { name: 'sam', age: 12 };
+  const second = { name: 'john', age: 13 };
+  const secondCopy = { name: 'john', age: 13 };
+  const [current, previous] = withPrevious(first, {
+    isEqual: (a, b) => a.name === b.name && a.age === b.age,
+  });
+
+  // Act and Assert
+  current.set(second);
+  current.set(secondCopy);
+  expect(get(current)).toBe(second);
+  expect(get(previous)).toBe(first);
+});
+

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -26,7 +26,7 @@ test('set one value', () => {
 
 test('init three values', () => {
   // Arrange
-  const [current, prev1, prev2] = withPrevious(0, 2);
+  const [current, prev1, prev2] = withPrevious(0, { numToTrack: 2 });
 
   // Assert
   expect(get(current)).toBe(0);
@@ -36,7 +36,7 @@ test('init three values', () => {
 
 test('set two values', () => {
   // Arrange
-  const [current, prev1, prev2] = withPrevious(0, 2);
+  const [current, prev1, prev2] = withPrevious(0, { numToTrack: 2 });
 
   // Act and Assert
   current.set(1);
@@ -56,6 +56,7 @@ test('set two values', () => {
 });
 
 test('init invalid no values', () => {
-  expect(withPrevious.bind(this, 0, 0)).toThrow('Must track at least 1 previous');
+  expect(withPrevious.bind(this, 0, { numToTrack: 0 }))
+      .toThrow('Must track at least 1 previous');
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,11 +9,9 @@ type IsEqual<T> = (a: T, b: T) => boolean;
 type NonNullFirstArray<T> = [T, ...(T|null)[]];
 type Updater<T> = (toUpdate: T) => T;
 
-const alwaysUpdate = <T>(a: T, b: T): boolean => false;
-
 export function withPrevious<T>(initValue: T, {
   numToTrack = 2,
-  isEqual = alwaysUpdate,
+  isEqual = (a, b) => a === b,
 }: WithPreviousOptions<T> = {}): [Writable<T>, ...Readable<T|null>[]] {
 
   if (numToTrack < 1) {
@@ -28,7 +26,7 @@ export function withPrevious<T>(initValue: T, {
     values.update($values => {
       const newValue = fn($values[0]);
       // Prevent updates if values are equal as defined by an isEqual
-      // comparison. By default, always update.
+      // comparison. By default, use a simple === comparison.
       if (isEqual(newValue, $values[0])) {
         return $values;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,10 +38,10 @@ export function withPrevious<T>(initValue: T, {
       ];
     });
   }
-  const current: Writable<T> = {
+  const current = {
     subscribe: derived(values, $values => $values[0]).subscribe,
     update: updateCurrent,
-    set: (newValue) => {
+    set: (newValue: T) => {
       updateCurrent(() => newValue);
     },
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import type { Writable, Readable } from 'svelte/store';
 
 interface WithPreviousOptions<T> {
   numToTrack?: number;
+  requireChange?: boolean;
   isEqual?: IsEqual<T>;
 }
 type IsEqual<T> = (a: T, b: T) => boolean;
@@ -11,8 +12,9 @@ type Updater<T> = (toUpdate: T) => T;
 
 export function withPrevious<T>(initValue: T, {
   numToTrack = 2,
+  requireChange = true,
   isEqual = (a, b) => a === b,
-}: WithPreviousOptions<T> = {}): [Writable<T>, ...Readable<T|null>[]] {
+}: Partial<WithPreviousOptions<T>> = {}): [Writable<T>, ...Readable<T|null>[]] {
 
   if (numToTrack < 1) {
     throw new Error('Must track at least 1 previous');
@@ -27,7 +29,7 @@ export function withPrevious<T>(initValue: T, {
       const newValue = fn($values[0]);
       // Prevent updates if values are equal as defined by an isEqual
       // comparison. By default, use a simple === comparison.
-      if (isEqual(newValue, $values[0])) {
+      if (requireChange && isEqual(newValue, $values[0])) {
         return $values;
       }
       // Adds the new value to the front of the array and removes the oldest


### PR DESCRIPTION
It is now possible to configure `withPrevious` to only update previous values if the new value is not equal to the current value.

Options are also provided to use a custom `isEqual` function.